### PR TITLE
[nrf noup] boards: don't set BUILD_WITH_TFM default for 91ns

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -8,12 +8,6 @@ if BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160NS
 config BOARD
 	default "nrf9160dk_nrf9160"
 
-# By default, if we build for a Non-Secure version of the board,
-# force building with TF-M as the Secure Execution Environment.
-
-config BUILD_WITH_TFM
-	default y if BOARD_NRF9160DK_NRF9160NS
-
 if BUILD_WITH_TFM
 
 # By default, if we build with TF-M, instruct build system to


### PR DESCRIPTION
SPM is the default for NCS. Revert this change to ensure
that SPM is set for NCS.

Ref: NCSDK-9282
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>